### PR TITLE
refine 2 bugs in test_FAB.py

### DIFF
--- a/src/test_FAB.py
+++ b/src/test_FAB.py
@@ -75,7 +75,7 @@ def test(resnet_model, is_training, F, H, F_curr, H_curr, input_images_blur,
     resume(sess, FLAGS.resume_video_deblur, FLAGS.video_deblur_train_dir, 'video_deblur_model_')
     resume(sess, FLAGS.resume_resnet, FLAGS.resnet_train_dir, 'resnet_model_')
     resume(sess, FLAGS.resume_all, FLAGS.end_2_end_train_dir, '')
-    
+
     ##############################################################################
 
     gt_file_path = os.path.join(FLAGS.end_2_end_test_dir,'gt.txt')
@@ -92,7 +92,7 @@ def test(resnet_model, is_training, F, H, F_curr, H_curr, input_images_blur,
                                        NUM_CLASSES = POINTS_NUM*2, sample_set='test')
 
     test_break_flag = False
-    for x in xrange(int(np.floor(len(dataset.train_table)/FLAGS.batch_size))):
+    for x in xrange(len(dataset.train_table)-2):
 
         step = sess.run(global_step)
 
@@ -142,12 +142,18 @@ def test(resnet_model, is_training, F, H, F_curr, H_curr, input_images_blur,
         for batch_num,pre in enumerate(pres):
             for v in pre:
                 pre_file.write(str(v*255.0)+' ')
-            pre_file.write(names[batch_num])
+            if len(names) > 1:
+                pre_file.write(names[-1])
+            else:
+                pre_file.write(names[batch_num])
             pre_file.write('\n')
         for batch_num,g in enumerate(landmark_gt_test):
             for v in g:
                 gt_file.write(str(v*255.0)+' ')
-            gt_file.write(names[batch_num])
+            if len(names) > 1:
+                gt_file.write(names[-1])
+            else:
+                gt_file.write(names[batch_num])
             gt_file.write('\n')
 
         img = input_images_blur_generated[0,:,:,0:3]*255


### PR DESCRIPTION
During the testing period, the testing dataset will be traversed only once. Since the first two images are skipped, the number of the total loops needs to reduced by 2 to be consistent with the number of the testing images.
In datagen.py, the length of "names" will first increase from 1 to 3, then maintain at 1 for every distinct image folder in the testing dataset. The first landmark localization predicted by FAB is of the last element in "names" when the length of "names" equals to 3. So in test_FAB.py, images written to pre_file and gt_file should be conditioned by the length of "names".